### PR TITLE
feat : 챗봇 구매 API 구현 및 동시성 문제 테스트

### DIFF
--- a/src/main/java/org/jungppo/bambooforest/battery/exception/BatteryBusinessException.java
+++ b/src/main/java/org/jungppo/bambooforest/battery/exception/BatteryBusinessException.java
@@ -1,14 +1,14 @@
 package org.jungppo.bambooforest.battery.exception;
 
+import org.jungppo.bambooforest.global.exception.domain.BusinessException;
 import org.jungppo.bambooforest.global.exception.domain.ExceptionType;
-import org.springframework.web.server.ResponseStatusException;
 
-public abstract class BatteryBusinessException extends ResponseStatusException {
+public abstract class BatteryBusinessException extends BusinessException {
     public BatteryBusinessException(final ExceptionType exceptionType) {
-        super(exceptionType.getStatus(), exceptionType.getMessage());
+        super(exceptionType);
     }
 
-    public BatteryBusinessException(final ExceptionType exceptionType, final String reason) {
-        super(exceptionType.getStatus(), reason);
+    public BatteryBusinessException(final ExceptionType exceptionType, final Throwable cause) {
+        super(exceptionType, cause);
     }
 }

--- a/src/main/java/org/jungppo/bambooforest/battery/exception/BatteryInsufficientException.java
+++ b/src/main/java/org/jungppo/bambooforest/battery/exception/BatteryInsufficientException.java
@@ -1,0 +1,9 @@
+package org.jungppo.bambooforest.battery.exception;
+
+import static org.jungppo.bambooforest.global.exception.domain.ExceptionType.BATTERY_INSUFFICIENT_EXCEPTION;
+
+public class BatteryInsufficientException extends BatteryBusinessException {
+    public BatteryInsufficientException() {
+        super(BATTERY_INSUFFICIENT_EXCEPTION);
+    }
+}

--- a/src/main/java/org/jungppo/bambooforest/chatbot/domain/ChatBotItem.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/domain/ChatBotItem.java
@@ -15,16 +15,17 @@ import lombok.RequiredArgsConstructor;
 public enum ChatBotItem {
 
     UNCLE_CHATBOT("아저씨 챗봇", "http://example.com/uncle", "아저씨와 대화를 나눌 수 있는 챗봇입니다.",
-            "http://example.com/images/uncle.png"),
+            "http://example.com/images/uncle.png", 100),
     AUNT_CHATBOT("아줌마 챗봇", "http://example.com/aunt", "아줌마와 대화를 나눌 수 있는 챗봇입니다.",
-            "http://example.com/images/aunt.png"),
+            "http://example.com/images/aunt.png", 150),
     CHILD_CHATBOT("어린이 챗봇", "http://example.com/child", "어린이와 대화를 나눌 수 있는 챗봇입니다.",
-            "http://example.com/images/child.png");
+            "http://example.com/images/child.png", 200);
 
     private final String name;
     private final String url;
     private final String description;
     private final String imageUrl;
+    private final int price;
 
     private static final Map<String, ChatBotItem> CHATBOT_MAP;
 

--- a/src/main/java/org/jungppo/bambooforest/chatbot/domain/ChatBotItem.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/domain/ChatBotItem.java
@@ -15,11 +15,11 @@ import lombok.RequiredArgsConstructor;
 public enum ChatBotItem {
 
     UNCLE_CHATBOT("아저씨 챗봇", "http://example.com/uncle", "아저씨와 대화를 나눌 수 있는 챗봇입니다.",
-            "http://example.com/images/uncle.png", 100),
+            "http://example.com/images/uncle.png", 0),
     AUNT_CHATBOT("아줌마 챗봇", "http://example.com/aunt", "아줌마와 대화를 나눌 수 있는 챗봇입니다.",
-            "http://example.com/images/aunt.png", 150),
+            "http://example.com/images/aunt.png", 3),
     CHILD_CHATBOT("어린이 챗봇", "http://example.com/child", "어린이와 대화를 나눌 수 있는 챗봇입니다.",
-            "http://example.com/images/child.png", 200);
+            "http://example.com/images/child.png", 5);
 
     private final String name;
     private final String url;

--- a/src/main/java/org/jungppo/bambooforest/chatbot/dto/ChatBotItemDto.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/dto/ChatBotItemDto.java
@@ -9,11 +9,13 @@ public class ChatBotItemDto {
     private final String url;
     private final String description;
     private final String imageUrl;
+    private final int price;
 
     public ChatBotItemDto(final ChatBotItem chatBotItem) {
         this.name = chatBotItem.getName();
         this.url = chatBotItem.getUrl();
         this.description = chatBotItem.getDescription();
         this.imageUrl = chatBotItem.getImageUrl();
+        this.price = chatBotItem.getPrice();
     }
 }

--- a/src/main/java/org/jungppo/bambooforest/chatbot/dto/ChatBotPurchaseRequest.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/dto/ChatBotPurchaseRequest.java
@@ -1,0 +1,16 @@
+package org.jungppo.bambooforest.chatbot.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatBotPurchaseRequest {
+    @NotBlank(message = "ChatBot item name cannot be blank")
+    @Size(max = 15, message = "ChatBot item name must be less than or equal to 15 characters")
+    private String chatBotItemName;
+}

--- a/src/main/java/org/jungppo/bambooforest/chatbot/exception/ChatBotAlreadyOwnedException.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/exception/ChatBotAlreadyOwnedException.java
@@ -1,0 +1,9 @@
+package org.jungppo.bambooforest.chatbot.exception;
+
+import static org.jungppo.bambooforest.global.exception.domain.ExceptionType.CHATBOT_ALREADY_OWNED_EXCEPTION;
+
+public class ChatBotAlreadyOwnedException extends ChatBotBusinessException {
+    public ChatBotAlreadyOwnedException() {
+        super(CHATBOT_ALREADY_OWNED_EXCEPTION);
+    }
+}

--- a/src/main/java/org/jungppo/bambooforest/chatbot/exception/ChatBotBusinessException.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/exception/ChatBotBusinessException.java
@@ -1,0 +1,14 @@
+package org.jungppo.bambooforest.chatbot.exception;
+
+import org.jungppo.bambooforest.global.exception.domain.BusinessException;
+import org.jungppo.bambooforest.global.exception.domain.ExceptionType;
+
+public abstract class ChatBotBusinessException extends BusinessException {
+    public ChatBotBusinessException(final ExceptionType exceptionType) {
+        super(exceptionType);
+    }
+
+    public ChatBotBusinessException(final ExceptionType exceptionType, final Throwable cause) {
+        super(exceptionType, cause);
+    }
+}

--- a/src/main/java/org/jungppo/bambooforest/chatbot/exception/ChatBotNotFoundException.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/exception/ChatBotNotFoundException.java
@@ -1,0 +1,9 @@
+package org.jungppo.bambooforest.chatbot.exception;
+
+import static org.jungppo.bambooforest.global.exception.domain.ExceptionType.CHATBOT_NOT_FOUND_EXCEPTION;
+
+public class ChatBotNotFoundException extends ChatBotBusinessException {
+    public ChatBotNotFoundException() {
+        super(CHATBOT_NOT_FOUND_EXCEPTION);
+    }
+}

--- a/src/main/java/org/jungppo/bambooforest/chatbot/presentation/ChatBotController.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/presentation/ChatBotController.java
@@ -38,6 +38,6 @@ public class ChatBotController {
     public ResponseEntity<Void> purchaseChatBot(@Valid @RequestBody final ChatBotPurchaseRequest chatBotPurchaseRequest,
                                                 @AuthenticationPrincipal final CustomOAuth2User customOAuth2User) {
         chatBotService.purchaseChatBot(chatBotPurchaseRequest, customOAuth2User);
-        return ResponseEntity.created(URI.create("/api/members")).build();
+        return ResponseEntity.created(URI.create("/api/members/profile")).build();
     }
 }

--- a/src/main/java/org/jungppo/bambooforest/chatbot/presentation/ChatBotController.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/presentation/ChatBotController.java
@@ -1,18 +1,30 @@
 package org.jungppo.bambooforest.chatbot.presentation;
 
+import jakarta.validation.Valid;
+import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
 import org.jungppo.bambooforest.chatbot.domain.ChatBotItem;
 import org.jungppo.bambooforest.chatbot.dto.ChatBotItemDto;
+import org.jungppo.bambooforest.chatbot.dto.ChatBotPurchaseRequest;
+import org.jungppo.bambooforest.chatbot.service.ChatBotService;
+import org.jungppo.bambooforest.global.oauth2.domain.CustomOAuth2User;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/chatbots")
 public class ChatBotController {
+
+    private final ChatBotService chatBotService;
 
     @GetMapping
     public ResponseEntity<List<ChatBotItemDto>> getChatBots() {
@@ -20,5 +32,12 @@ public class ChatBotController {
                 .map(ChatBotItemDto::new)
                 .collect(Collectors.toList());
         return ResponseEntity.ok().body(chatBotTypeDtos);
+    }
+
+    @PostMapping("/purchase")
+    public ResponseEntity<Void> purchaseChatBot(@Valid @RequestBody final ChatBotPurchaseRequest chatBotPurchaseRequest,
+                                                @AuthenticationPrincipal final CustomOAuth2User customOAuth2User) {
+        chatBotService.purchaseChatBot(chatBotPurchaseRequest, customOAuth2User);
+        return ResponseEntity.created(URI.create("/api/members")).build();
     }
 }

--- a/src/main/java/org/jungppo/bambooforest/chatbot/service/ChatBotService.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/service/ChatBotService.java
@@ -1,7 +1,33 @@
 package org.jungppo.bambooforest.chatbot.service;
 
+import lombok.RequiredArgsConstructor;
+import org.jungppo.bambooforest.chatbot.domain.ChatBotItem;
+import org.jungppo.bambooforest.chatbot.dto.ChatBotPurchaseRequest;
+import org.jungppo.bambooforest.chatbot.exception.ChatBotNotFoundException;
+import org.jungppo.bambooforest.global.oauth2.domain.CustomOAuth2User;
+import org.jungppo.bambooforest.member.domain.entity.MemberEntity;
+import org.jungppo.bambooforest.member.domain.repository.MemberRepository;
+import org.jungppo.bambooforest.member.exception.MemberNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class ChatBotService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void purchaseChatBot(final ChatBotPurchaseRequest chatBotPurchaseRequest,
+                                final CustomOAuth2User customOAuth2User) {
+        final ChatBotItem chatBotItem = ChatBotItem.findByName(chatBotPurchaseRequest.getChatBotItemName())
+                .orElseThrow(ChatBotNotFoundException::new);
+        final MemberEntity memberEntity = memberRepository.findById(customOAuth2User.getId())
+                .orElseThrow(MemberNotFoundException::new);
+
+        memberEntity.subtractBatteries(chatBotItem.getPrice());
+        memberEntity.addChatBot(chatBotItem);
+    }
+
 }

--- a/src/main/java/org/jungppo/bambooforest/global/config/WebSocketConfig.java
+++ b/src/main/java/org/jungppo/bambooforest/global/config/WebSocketConfig.java
@@ -3,6 +3,7 @@ package org.jungppo.bambooforest.global.config;
 import org.jungppo.bambooforest.chat.handler.WebSocketServerHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
@@ -12,6 +13,7 @@ import org.springframework.web.socket.server.support.HttpSessionHandshakeInterce
 
 @Configuration
 @EnableWebSocket
+@Profile("!test")  // TODO. 테스트 코드에서 관리하도록 수정해야함.
 public class WebSocketConfig implements WebSocketConfigurer {
 
     @Override
@@ -25,7 +27,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
     public WebSocketHandler webSocketHandler() {
         return new WebSocketServerHandler();
     }
-    
+
     @Bean
     public ServletServerContainerFactoryBean createWebSocketContainer() {
         ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();

--- a/src/main/java/org/jungppo/bambooforest/global/exception/domain/ExceptionType.java
+++ b/src/main/java/org/jungppo/bambooforest/global/exception/domain/ExceptionType.java
@@ -24,9 +24,11 @@ public enum ExceptionType {
     MEMBER_NOT_FOUND_EXCEPTION(NOT_FOUND, "E008", "The specified member could not be found."),
     UNSUPPORTED_OAUTH2_EXCEPTION(INTERNAL_SERVER_ERROR, "E009", "Unsupported OAuth2 provider."),
     BATTERY_NOT_FOUND_EXCEPTION(NOT_FOUND, "E010", "The specified battery item could not be found."),
-    PAYMENT_NOT_FOUND_EXCEPTION(NOT_FOUND, "E011", "The specified payment could not be found."),
-    PAYMENT_FAILURE_EXCEPTION(BAD_REQUEST, "E012", "Failed to processing payment."),
-    CHATBOT_NOT_FOUND_EXCEPTION(NOT_FOUND, "E013", "The specified chatBot item could not be found."),
+    BATTERY_INSUFFICIENT_EXCEPTION(BAD_REQUEST, "E011", "Not enough batteries to purchase the chatbot."),
+    PAYMENT_NOT_FOUND_EXCEPTION(NOT_FOUND, "E012", "The specified payment could not be found."),
+    PAYMENT_FAILURE_EXCEPTION(BAD_REQUEST, "E013", "Failed to processing payment."),
+    CHATBOT_NOT_FOUND_EXCEPTION(NOT_FOUND, "E014", "The specified chatBot item could not be found."),
+    CHATBOT_ALREADY_OWNED_EXCEPTION(BAD_REQUEST, "E015", "The specified chatBot item is already owned by the user."),
     ;
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/org/jungppo/bambooforest/global/exception/domain/ExceptionType.java
+++ b/src/main/java/org/jungppo/bambooforest/global/exception/domain/ExceptionType.java
@@ -26,6 +26,7 @@ public enum ExceptionType {
     BATTERY_NOT_FOUND_EXCEPTION(NOT_FOUND, "E010", "The specified battery item could not be found."),
     PAYMENT_NOT_FOUND_EXCEPTION(NOT_FOUND, "E011", "The specified payment could not be found."),
     PAYMENT_FAILURE_EXCEPTION(BAD_REQUEST, "E012", "Failed to processing payment."),
+    CHATBOT_NOT_FOUND_EXCEPTION(NOT_FOUND, "E013", "The specified chatBot item could not be found."),
     ;
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/org/jungppo/bambooforest/member/domain/entity/RefreshTokenEntity.java
+++ b/src/main/java/org/jungppo/bambooforest/member/domain/entity/RefreshTokenEntity.java
@@ -21,7 +21,7 @@ public class RefreshTokenEntity extends JpaBaseEntity {
     @Column(name = "refresh_token_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(name = "`value`", unique = true, nullable = false)
     private String value;
 
     @Builder

--- a/src/test/java/org/jungppo/bambooforest/ChatBotServiceConcurrencyTest.java
+++ b/src/test/java/org/jungppo/bambooforest/ChatBotServiceConcurrencyTest.java
@@ -1,0 +1,114 @@
+package org.jungppo.bambooforest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.jungppo.bambooforest.chatbot.dto.ChatBotPurchaseRequest;
+import org.jungppo.bambooforest.chatbot.service.ChatBotService;
+import org.jungppo.bambooforest.global.oauth2.domain.CustomOAuth2User;
+import org.jungppo.bambooforest.member.domain.entity.MemberEntity;
+import org.jungppo.bambooforest.member.domain.entity.OAuth2Type;
+import org.jungppo.bambooforest.member.domain.entity.RoleType;
+import org.jungppo.bambooforest.member.domain.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@ActiveProfiles("test")
+public class ChatBotServiceConcurrencyTest {
+
+    @Autowired
+    private ChatBotService chatBotService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    /**
+     * 테스트에서 @Transactional과 ExecutorService가 생성한 스레드의 Transactional이 다름. ExecutorService에서 초기 데이터를 조회하지 못함.
+     * 테스트에서@Transactional를 사용하지 않고 명시적으로 데이터베이스 초기화.
+     */
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    private CustomOAuth2User customOAuth2User;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleaner.clean();
+
+        MemberEntity memberEntity = MemberEntity.builder()
+                .name("testUser")
+                .oAuth2(OAuth2Type.OAUTH2_GITHUB)
+                .username("testUser")
+                .profileImage("testProfileImage")
+                .role(RoleType.ROLE_USER)
+                .build();
+
+        memberEntity.addBatteries(100);
+        MemberEntity savedMemberEntity = memberRepository.save(memberEntity);
+        customOAuth2User = mock(CustomOAuth2User.class);
+        when(customOAuth2User.getId()).thenReturn(savedMemberEntity.getId());
+    }
+
+    @Test
+    void testConcurrentPurchaseRequests() throws InterruptedException {
+        int numberOfThreads = 3;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        ChatBotPurchaseRequest purchaseRequest1 = new ChatBotPurchaseRequest("아저씨 챗봇");
+        ChatBotPurchaseRequest purchaseRequest2 = new ChatBotPurchaseRequest("아줌마 챗봇");
+        ChatBotPurchaseRequest purchaseRequest3 = new ChatBotPurchaseRequest("어린이 챗봇");
+
+        ChatBotPurchaseRequest[] purchaseRequests = {purchaseRequest1, purchaseRequest2, purchaseRequest3};
+
+        for (ChatBotPurchaseRequest purchaseRequest : purchaseRequests) {
+            executorService.submit(() -> {
+                try {
+                    chatBotService.purchaseChatBot(purchaseRequest, customOAuth2User);
+                } catch (Exception e) {
+                    System.out.println(e.getMessage());
+                }
+            });
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+        MemberEntity updatedMemberEntity = memberRepository.findById(customOAuth2User.getId())
+                .orElseThrow(() -> new IllegalStateException("Member not found"));
+
+        System.out.println("Remaining batteries: " + updatedMemberEntity.getBatteryCount());
+        System.out.println("Purchased chatbots: " + updatedMemberEntity.getChatBots());
+    }
+
+    @Test
+    void testSequentialPurchaseRequests() {
+        ChatBotPurchaseRequest purchaseRequest1 = new ChatBotPurchaseRequest("아저씨 챗봇");
+        ChatBotPurchaseRequest purchaseRequest2 = new ChatBotPurchaseRequest("아줌마 챗봇");
+        ChatBotPurchaseRequest purchaseRequest3 = new ChatBotPurchaseRequest("어린이 챗봇");
+
+        try {
+            chatBotService.purchaseChatBot(purchaseRequest1, customOAuth2User);
+            chatBotService.purchaseChatBot(purchaseRequest2, customOAuth2User);
+            chatBotService.purchaseChatBot(purchaseRequest3, customOAuth2User);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+
+        MemberEntity updatedMemberEntity = memberRepository.findById(customOAuth2User.getId())
+                .orElseThrow(() -> new IllegalStateException("Member not found"));
+
+        System.out.println("Remaining batteries: " + updatedMemberEntity.getBatteryCount());
+        System.out.println("Purchased chatbots: " + updatedMemberEntity.getChatBots());
+    }
+}

--- a/src/test/java/org/jungppo/bambooforest/ChatBotServiceConcurrencyTest.java
+++ b/src/test/java/org/jungppo/bambooforest/ChatBotServiceConcurrencyTest.java
@@ -14,10 +14,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+@SpringBootTest
 @ActiveProfiles("test")
 public class ChatBotServiceConcurrencyTest {
 

--- a/src/test/java/org/jungppo/bambooforest/ChatBotServiceConcurrencyTest.java
+++ b/src/test/java/org/jungppo/bambooforest/ChatBotServiceConcurrencyTest.java
@@ -1,8 +1,5 @@
 package org.jungppo.bambooforest;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -15,14 +12,11 @@ import org.jungppo.bambooforest.member.domain.entity.RoleType;
 import org.jungppo.bambooforest.member.domain.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 @ActiveProfiles("test")
 public class ChatBotServiceConcurrencyTest {
@@ -56,8 +50,8 @@ public class ChatBotServiceConcurrencyTest {
 
         memberEntity.addBatteries(100);
         MemberEntity savedMemberEntity = memberRepository.save(memberEntity);
-        customOAuth2User = mock(CustomOAuth2User.class);
-        when(customOAuth2User.getId()).thenReturn(savedMemberEntity.getId());
+        customOAuth2User = new CustomOAuth2User(savedMemberEntity.getId(), savedMemberEntity.getRole(),
+                savedMemberEntity.getOAuth2());
     }
 
     @Test

--- a/src/test/java/org/jungppo/bambooforest/DatabaseCleaner.java
+++ b/src/test/java/org/jungppo/bambooforest/DatabaseCleaner.java
@@ -1,0 +1,48 @@
+package org.jungppo.bambooforest;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Table;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Profile(value = "test")
+public class DatabaseCleaner implements InitializingBean {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() {
+        tableNames = entityManager.getMetamodel().getEntities().stream()
+                .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
+                .map(e -> {
+                    Table table = e.getJavaType().getAnnotation(Table.class);
+                    return table != null ? table.name() : toSnakeCase(e.getName());
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void clean() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+        }
+
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+
+    private String toSnakeCase(String str) {
+        return str.replaceAll("([a-z])([A-Z]+)", "$1_$2").toLowerCase();
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,30 @@
+spring:
+  h2:
+    console:
+      enabled: true # /h2-console 설정
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:bamboo_forest
+    username: sa
+    password:
+
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+        hbm2ddl.auto: create
+        default_batch_fetch_size: 100
+    open-in-view: false
+    show-sql: true
+
+api:
+  url: http://localhost:8080
+
+logging:
+  level:
+    org.hibernate.orm.jdbc.bind: trace
+#    org.springframework.transaction.interceptor: trace
+
+websocket:
+  uri: ws://localhost:5000/ws


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #18 

## ✨ PR 세부 내용
 - 배터리 개수를 차감하고, 챗봇을 제공하는 로직 구현
 - 사용자의 배터리 개수가 부족할 경우, 구매 불가 메시지를 출력
 - 사용자가 이미 보유한 챗봇일 경우, 구매 불가 메시지를 출력
 
## 📄 참고 사항
챗봇을 구매하는 요청을 동시에 보낼 경우 동시성 문제가 발생하였습니다.

- 순차 요청
![image](https://github.com/user-attachments/assets/cc45a5a5-dbc4-4c5c-876e-116cd370fd5f)
> 순차적으로 요청을 보낼 경우, 정상적으로 배터리 개수가 차감되고, 챗봇을 보유합니다.

- 병렬 요청
  - 테스트 1
![image](https://github.com/user-attachments/assets/bd61ae5c-82ab-425e-83af-fbd8a1687288)
  - 테스트 2
![image](https://github.com/user-attachments/assets/dfd02117-6513-4843-b3c4-ffbeb73d9aea)
> 병렬적으로 요청을 보낼경우 마지막으로 반영된 구매 요청만 반영됩니다. 즉, 확률적으로 챗봇이 구매됩니다.

또한 동시성 문제 말고도 현재 로직은 사용자의 배터리 구매 및 사용 내역을 제공하지 못합니다. 다음에는 이러한 문제를 해결하겠습니다.

<!-- 수정/추가한 내용을 적어주세요. -->
