### PR TITLE
feat : 결제 내역 조회 API 구현

### DIFF
--- a/src/main/java/org/jungppo/bambooforest/battery/dto/BatteryItemDto.java
+++ b/src/main/java/org/jungppo/bambooforest/battery/dto/BatteryItemDto.java
@@ -2,17 +2,21 @@ package org.jungppo.bambooforest.battery.dto;
 
 import java.math.BigDecimal;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.jungppo.bambooforest.battery.domain.BatteryItem;
 
 @Getter
+@RequiredArgsConstructor
 public class BatteryItemDto {
     private final String name;
     private final BigDecimal price;
     private final int count;
 
-    public BatteryItemDto(final BatteryItem batteryItem) {
-        this.name = batteryItem.getName();
-        this.price = batteryItem.getPrice();
-        this.count = batteryItem.getCount();
+    public static BatteryItemDto from(final BatteryItem batteryItem) {
+        return new BatteryItemDto(
+                batteryItem.getName(),
+                batteryItem.getPrice(),
+                batteryItem.getCount()
+        );
     }
 }

--- a/src/main/java/org/jungppo/bambooforest/battery/presentation/BatteryController.java
+++ b/src/main/java/org/jungppo/bambooforest/battery/presentation/BatteryController.java
@@ -3,7 +3,6 @@ package org.jungppo.bambooforest.battery.presentation;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.jungppo.bambooforest.battery.domain.BatteryItem;
 import org.jungppo.bambooforest.battery.dto.BatteryItemDto;
 import org.springframework.http.ResponseEntity;
@@ -15,11 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/batteries")
 public class BatteryController {
 
-	@GetMapping
-	public ResponseEntity<List<BatteryItemDto>> getBatteries() {
-		final List<BatteryItemDto> batteryItemDtos = Stream.of(BatteryItem.values())
-			.map(BatteryItemDto::new)
-			.collect(Collectors.toList());
-		return ResponseEntity.ok().body(batteryItemDtos);
-	}
+    @GetMapping
+    public ResponseEntity<List<BatteryItemDto>> getBatteries() {
+        final List<BatteryItemDto> batteryItemDtos = Stream.of(BatteryItem.values())
+                .map(BatteryItemDto::from)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok().body(batteryItemDtos);
+    }
 }

--- a/src/main/java/org/jungppo/bambooforest/chatbot/dto/ChatBotItemDto.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/dto/ChatBotItemDto.java
@@ -1,9 +1,11 @@
 package org.jungppo.bambooforest.chatbot.dto;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.jungppo.bambooforest.chatbot.domain.ChatBotItem;
 
 @Getter
+@RequiredArgsConstructor
 public class ChatBotItemDto {
     private final String name;
     private final String url;
@@ -11,11 +13,13 @@ public class ChatBotItemDto {
     private final String imageUrl;
     private final int price;
 
-    public ChatBotItemDto(final ChatBotItem chatBotItem) {
-        this.name = chatBotItem.getName();
-        this.url = chatBotItem.getUrl();
-        this.description = chatBotItem.getDescription();
-        this.imageUrl = chatBotItem.getImageUrl();
-        this.price = chatBotItem.getPrice();
+    public static ChatBotItemDto from(final ChatBotItem chatBotItem) {
+        return new ChatBotItemDto(
+                chatBotItem.getName(),
+                chatBotItem.getUrl(),
+                chatBotItem.getDescription(),
+                chatBotItem.getImageUrl(),
+                chatBotItem.getPrice()
+        );
     }
 }

--- a/src/main/java/org/jungppo/bambooforest/chatbot/presentation/ChatBotController.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/presentation/ChatBotController.java
@@ -29,7 +29,7 @@ public class ChatBotController {
     @GetMapping
     public ResponseEntity<List<ChatBotItemDto>> getChatBots() {
         final List<ChatBotItemDto> chatBotTypeDtos = Stream.of(ChatBotItem.values())
-                .map(ChatBotItemDto::new)
+                .map(ChatBotItemDto::from)
                 .collect(Collectors.toList());
         return ResponseEntity.ok().body(chatBotTypeDtos);
     }

--- a/src/main/java/org/jungppo/bambooforest/member/dto/MemberDto.java
+++ b/src/main/java/org/jungppo/bambooforest/member/dto/MemberDto.java
@@ -32,7 +32,7 @@ public class MemberDto {
                 memberEntity.getProfileImage(),
                 memberEntity.getRole(),
                 memberEntity.getBatteryCount(),
-                memberEntity.getChatBots().stream().map(ChatBotItemDto::new).toList(),
+                memberEntity.getChatBots().stream().map(ChatBotItemDto::from).toList(),
                 memberEntity.getCreatedAt()
         );
     }

--- a/src/main/java/org/jungppo/bambooforest/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/org/jungppo/bambooforest/payment/domain/repository/PaymentRepository.java
@@ -4,5 +4,5 @@ import java.util.UUID;
 import org.jungppo.bambooforest.payment.domain.entity.PaymentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PaymentRepository extends JpaRepository<PaymentEntity, UUID> {
+public interface PaymentRepository extends JpaRepository<PaymentEntity, UUID>, QuerydslPaymentRepository {
 }

--- a/src/main/java/org/jungppo/bambooforest/payment/domain/repository/QuerydslPaymentRepository.java
+++ b/src/main/java/org/jungppo/bambooforest/payment/domain/repository/QuerydslPaymentRepository.java
@@ -1,0 +1,8 @@
+package org.jungppo.bambooforest.payment.domain.repository;
+
+import java.util.List;
+import org.jungppo.bambooforest.payment.domain.entity.PaymentEntity;
+
+public interface QuerydslPaymentRepository {
+    List<PaymentEntity> findAllCompletedByMemberIdOrderByCreatedAtDesc(Long memberId);
+}

--- a/src/main/java/org/jungppo/bambooforest/payment/domain/repository/paymentRepositoryImpl.java
+++ b/src/main/java/org/jungppo/bambooforest/payment/domain/repository/paymentRepositoryImpl.java
@@ -1,0 +1,32 @@
+package org.jungppo.bambooforest.payment.domain.repository;
+
+import static org.jungppo.bambooforest.payment.domain.entity.QPaymentEntity.paymentEntity;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.jungppo.bambooforest.payment.domain.entity.PaymentEntity;
+import org.jungppo.bambooforest.payment.domain.entity.PaymentStatusType;
+
+@RequiredArgsConstructor
+public class paymentRepositoryImpl implements QuerydslPaymentRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<PaymentEntity> findAllCompletedByMemberIdOrderByCreatedAtDesc(Long memberId) {
+        return queryFactory.selectFrom(paymentEntity)
+                .where(memberIdEquals(memberId)
+                        .and(statusIsCompleted()))
+                .orderBy(paymentEntity.createdAt.desc())
+                .fetch();
+    }
+
+    private BooleanExpression memberIdEquals(Long memberId) {
+        return paymentEntity.member.id.eq(memberId);
+    }
+
+    private BooleanExpression statusIsCompleted() {
+        return paymentEntity.status.eq(PaymentStatusType.COMPLETED);
+    }
+}

--- a/src/main/java/org/jungppo/bambooforest/payment/presentation/PaymentController.java
+++ b/src/main/java/org/jungppo/bambooforest/payment/presentation/PaymentController.java
@@ -3,6 +3,7 @@ package org.jungppo.bambooforest.payment.presentation;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jungppo.bambooforest.global.oauth2.domain.CustomOAuth2User;
@@ -13,6 +14,7 @@ import org.jungppo.bambooforest.member.dto.PaymentSetupResponse;
 import org.jungppo.bambooforest.payment.service.PaymentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,5 +42,12 @@ public class PaymentController {
             @Valid @RequestBody final PaymentConfirmRequest paymentConfirmRequest) {
         final PaymentDto paymentDto = paymentService.confirmPayment(paymentConfirmRequest);
         return ResponseEntity.ok().body(paymentDto);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PaymentDto>> getPayments(
+            @AuthenticationPrincipal final CustomOAuth2User customOAuth2User) {
+        final List<PaymentDto> paymentDtos = paymentService.getPayments(customOAuth2User);
+        return ResponseEntity.ok().body(paymentDtos);
     }
 }

--- a/src/main/java/org/jungppo/bambooforest/payment/service/PaymentService.java
+++ b/src/main/java/org/jungppo/bambooforest/payment/service/PaymentService.java
@@ -1,6 +1,7 @@
 package org.jungppo.bambooforest.payment.service;
 
 import java.math.BigDecimal;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.jungppo.bambooforest.battery.domain.BatteryItem;
 import org.jungppo.bambooforest.battery.exception.BatteryNotFoundException;
@@ -80,5 +81,11 @@ public class PaymentService {
                 paymentResponse.getAmount());
         paymentEntity.updatePaymentStatus(PaymentStatusType.COMPLETED);
         paymentEntity.getMember().addBatteries(paymentEntity.getBatteryItem().getCount());
+    }
+
+    public List<PaymentDto> getPayments(final CustomOAuth2User customOAuth2User) {
+        List<PaymentEntity> paymentEntities = paymentRepository.findAllCompletedByMemberIdOrderByCreatedAtDesc(
+                customOAuth2User.getId());
+        return paymentEntities.stream().map(PaymentDto::from).toList();
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #17

## ✨ PR 세부 내용
 - 클라이언트 측과 반환 양식에 대한 협의 : 클라이언트 측에서 요청한 리스트 형식으로 반환하도록 구현했습니다.

 - 결제 내역 조회 기능 구현 : 성공한 결제내역이면서 최신순으로 정렬하여 반환합니다.
<!-- 수정/추가한 내용을 적어주세요. -->
