### PR TITLE
feat : 배터리 구매에서 동시성 문제를 외부 API의 특성을 고려하여 Pessimistic Lock을 이용하여 해결

### DIFF
--- a/src/main/java/org/jungppo/bambooforest/chatbot/service/ChatBotPurchaseService.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/service/ChatBotPurchaseService.java
@@ -35,7 +35,7 @@ public class ChatBotPurchaseService {
                                 final CustomOAuth2User customOAuth2User) {
         final ChatBotItem chatBotItem = ChatBotItem.findByName(chatBotPurchaseRequest.getChatBotItemName())
                 .orElseThrow(ChatBotNotFoundException::new);
-        final MemberEntity memberEntity = memberRepository.findByIdWithLock(customOAuth2User.getId())
+        final MemberEntity memberEntity = memberRepository.findByIdWithOptimisticLock(customOAuth2User.getId())
                 .orElseThrow(MemberNotFoundException::new);
 
         memberEntity.subtractBatteries(chatBotItem.getPrice());

--- a/src/main/java/org/jungppo/bambooforest/global/client/paymentgateway/toss/TossPaymentGatewayClient.java
+++ b/src/main/java/org/jungppo/bambooforest/global/client/paymentgateway/toss/TossPaymentGatewayClient.java
@@ -28,7 +28,7 @@ import org.springframework.web.client.RestTemplate;
 @EnableConfigurationProperties(PaymentGatewayProperties.class)
 public class TossPaymentGatewayClient implements PaymentGatewayClient {
 
-    private static final String TOSS_PAYMENT_URL = "https://api.tosspayments.com/v1/payments/confirm";
+    public static final String TOSS_PAYMENT_URL = "https://api.tosspayments.com/v1/payments/confirm";
     private final RestTemplate restTemplate;
     private final PaymentGatewayProperties paymentGatewayProperties;
 

--- a/src/main/java/org/jungppo/bambooforest/global/client/paymentgateway/toss/dto/TossPaymentRequest.java
+++ b/src/main/java/org/jungppo/bambooforest/global/client/paymentgateway/toss/dto/TossPaymentRequest.java
@@ -2,10 +2,12 @@ package org.jungppo.bambooforest.global.client.paymentgateway.toss.dto;
 
 import java.math.BigDecimal;
 import java.util.UUID;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.jungppo.bambooforest.global.client.paymentgateway.dto.PaymentRequest;
 
+@EqualsAndHashCode
 @Getter
 @RequiredArgsConstructor
 public class TossPaymentRequest implements PaymentRequest {

--- a/src/main/java/org/jungppo/bambooforest/member/domain/repository/MemberRepository.java
+++ b/src/main/java/org/jungppo/bambooforest/member/domain/repository/MemberRepository.java
@@ -1,7 +1,6 @@
 package org.jungppo.bambooforest.member.domain.repository;
 
 
-
 import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.jungppo.bambooforest.member.domain.entity.MemberEntity;
@@ -14,8 +13,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<MemberEntity, Long>, QuerydslMemberRepository {
     Optional<MemberEntity> findByUsername(String username);
-  
+
     @Lock(LockModeType.OPTIMISTIC)
     @Query("select m from MemberEntity m where m.id = :id")
-    Optional<MemberEntity> findByIdWithLock(@Param("id") Long id);
+    Optional<MemberEntity> findByIdWithOptimisticLock(@Param("id") Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select m from MemberEntity m where m.id = :id")
+    Optional<MemberEntity> findByIdWithPessimisticLock(@Param("id") Long id);
 }

--- a/src/main/java/org/jungppo/bambooforest/member/domain/repository/MemberRepositoryImpl.java
+++ b/src/main/java/org/jungppo/bambooforest/member/domain/repository/MemberRepositoryImpl.java
@@ -4,6 +4,7 @@ import static org.jungppo.bambooforest.member.domain.entity.QMemberEntity.member
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.jungppo.bambooforest.member.domain.entity.MemberEntity;
@@ -17,6 +18,26 @@ public class MemberRepositoryImpl implements QuerydslMemberRepository {
         return Optional.ofNullable(
                 queryFactory.selectFrom(memberEntity)
                         .where(nameEquals(name))
+                        .fetchOne()
+        );
+    }
+
+    @Override
+    public Optional<MemberEntity> findByIdWithOptimisticLock(final Long id) {
+        return Optional.ofNullable(
+                queryFactory.selectFrom(memberEntity)
+                        .where(idEquals(id))
+                        .setLockMode(LockModeType.OPTIMISTIC)
+                        .fetchOne()
+        );
+    }
+
+    @Override
+    public Optional<MemberEntity> findByIdWithPessimisticLock(final Long id) {
+        return Optional.ofNullable(
+                queryFactory.selectFrom(memberEntity)
+                        .where(idEquals(id))
+                        .setLockMode(LockModeType.PESSIMISTIC_WRITE)
                         .fetchOne()
         );
     }

--- a/src/main/java/org/jungppo/bambooforest/member/domain/repository/QuerydslMemberRepository.java
+++ b/src/main/java/org/jungppo/bambooforest/member/domain/repository/QuerydslMemberRepository.java
@@ -5,4 +5,8 @@ import org.jungppo.bambooforest.member.domain.entity.MemberEntity;
 
 public interface QuerydslMemberRepository {
     Optional<MemberEntity> findByName(final String name);
+
+    Optional<MemberEntity> findByIdWithOptimisticLock(final Long id);
+
+    Optional<MemberEntity> findByIdWithPessimisticLock(final Long id);
 }

--- a/src/main/java/org/jungppo/bambooforest/member/presentation/MemberController.java
+++ b/src/main/java/org/jungppo/bambooforest/member/presentation/MemberController.java
@@ -7,8 +7,6 @@ import lombok.RequiredArgsConstructor;
 import org.jungppo.bambooforest.global.jwt.dto.JwtDto;
 import org.jungppo.bambooforest.global.oauth2.domain.CustomOAuth2User;
 import org.jungppo.bambooforest.member.dto.MemberDto;
-import org.jungppo.bambooforest.member.exception.InvalidRefreshTokenException;
-import org.jungppo.bambooforest.member.exception.RefreshTokenFailureException;
 import org.jungppo.bambooforest.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -39,11 +37,7 @@ public class MemberController {
 
     @PostMapping("/reissuance")
     public ResponseEntity<JwtDto> reissuanceToken(@RequestHeader(value = AUTHORIZATION) final String refreshToken) {
-        try {
-            final JwtDto jwtDto = memberService.reissuanceToken(refreshToken);
-            return ResponseEntity.status(CREATED).body(jwtDto);
-        } catch (final InvalidRefreshTokenException e) {   // TODO. 함수형 인터페이스를 이용한 Refactoring
-            throw new RefreshTokenFailureException();
-        }
+        final JwtDto jwtDto = memberService.reissuanceToken(refreshToken);
+        return ResponseEntity.status(CREATED).body(jwtDto);
     }
 }

--- a/src/main/java/org/jungppo/bambooforest/payment/presentation/PaymentController.java
+++ b/src/main/java/org/jungppo/bambooforest/payment/presentation/PaymentController.java
@@ -40,8 +40,9 @@ public class PaymentController {
 
     @PostMapping("/confirm")
     public ResponseEntity<PaymentDto> confirmPayment(
-            @Valid @RequestBody final PaymentConfirmRequest paymentConfirmRequest) {
-        final UUID paymentId = paymentService.confirmPayment(paymentConfirmRequest);
+            @Valid @RequestBody final PaymentConfirmRequest paymentConfirmRequest,
+            @AuthenticationPrincipal final CustomOAuth2User customOAuth2User) {
+        final UUID paymentId = paymentService.confirmPayment(paymentConfirmRequest, customOAuth2User);
         return ResponseEntity.created(URI.create("/api/payments/" + paymentId)).build();
     }
 

--- a/src/main/java/org/jungppo/bambooforest/payment/service/PaymentService.java
+++ b/src/main/java/org/jungppo/bambooforest/payment/service/PaymentService.java
@@ -23,7 +23,9 @@ import org.jungppo.bambooforest.payment.domain.repository.PaymentRepository;
 import org.jungppo.bambooforest.payment.exception.PaymentFailureException;
 import org.jungppo.bambooforest.payment.exception.PaymentNotFoundException;
 import org.jungppo.bambooforest.payment.exception.PaymentPendingException;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.repository.query.Param;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,6 +56,7 @@ public class PaymentService {
         return new PaymentSetupResponse(paymentEntity.getId(), paymentEntity.getBatteryItem().getPrice());
     }
 
+    @Retryable(retryFor = {OptimisticLockingFailureException.class})
     @Transactional
     public UUID confirmPayment(final PaymentConfirmRequest paymentConfirmRequest) {
         final PaymentEntity paymentEntity = paymentRepository.findById(paymentConfirmRequest.getOrderId())

--- a/src/test/java/org/jungppo/bambooforest/ChatBotPurchaseServiceConcurrencyTest.java
+++ b/src/test/java/org/jungppo/bambooforest/ChatBotPurchaseServiceConcurrencyTest.java
@@ -16,6 +16,7 @@ import org.jungppo.bambooforest.member.domain.entity.MemberEntity;
 import org.jungppo.bambooforest.member.domain.entity.OAuth2Type;
 import org.jungppo.bambooforest.member.domain.entity.RoleType;
 import org.jungppo.bambooforest.member.domain.repository.MemberRepository;
+import org.jungppo.bambooforest.member.exception.MemberNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,9 +71,10 @@ public class ChatBotPurchaseServiceConcurrencyTest {
         }
 
         final MemberEntity updatedMemberEntity = memberRepository.findById(customOAuth2User.getId())
-                .orElseThrow(() -> new IllegalStateException("Member not found"));
+                .orElseThrow(MemberNotFoundException::new);
 
-        assertEquals(92, updatedMemberEntity.getBatteryCount(), "Remaining batteries should be 92");
+        assertEquals(92, updatedMemberEntity.getBatteryCount(),
+                "Remaining batteries should be 92");
         assertTrue(updatedMemberEntity.getChatBots().contains(UNCLE_CHATBOT),
                 "Purchased chatbots should contain UNCLE_CHATBOT");
         assertTrue(updatedMemberEntity.getChatBots().contains(AUNT_CHATBOT),
@@ -108,9 +110,10 @@ public class ChatBotPurchaseServiceConcurrencyTest {
         countDownLatch.await();
 
         final MemberEntity updatedMemberEntity = memberRepository.findById(customOAuth2User.getId())
-                .orElseThrow(() -> new IllegalStateException("Member not found"));
+                .orElseThrow(MemberNotFoundException::new);
 
-        assertEquals(92, updatedMemberEntity.getBatteryCount(), "Remaining batteries should be 92");
+        assertEquals(92, updatedMemberEntity.getBatteryCount(),
+                "Remaining batteries should be 92");
         assertTrue(updatedMemberEntity.getChatBots().contains(UNCLE_CHATBOT),
                 "Purchased chatbots should contain UNCLE_CHATBOT");
         assertTrue(updatedMemberEntity.getChatBots().contains(AUNT_CHATBOT),

--- a/src/test/java/org/jungppo/bambooforest/ChatBotPurchaseServiceConcurrencyTest.java
+++ b/src/test/java/org/jungppo/bambooforest/ChatBotPurchaseServiceConcurrencyTest.java
@@ -24,7 +24,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class ChatBotServiceConcurrencyTest {
+public class ChatBotPurchaseServiceConcurrencyTest {
 
     @Autowired
     private ChatBotPurchaseService chatBotPurchaseService;

--- a/src/test/java/org/jungppo/bambooforest/PaymentServiceConcurrencyTest.java
+++ b/src/test/java/org/jungppo/bambooforest/PaymentServiceConcurrencyTest.java
@@ -1,0 +1,232 @@
+package org.jungppo.bambooforest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.jungppo.bambooforest.battery.domain.BatteryItem;
+import org.jungppo.bambooforest.global.client.dto.ClientResponse;
+import org.jungppo.bambooforest.global.client.paymentgateway.PaymentGatewayClient;
+import org.jungppo.bambooforest.global.client.paymentgateway.toss.dto.TossPaymentRequest;
+import org.jungppo.bambooforest.global.client.paymentgateway.toss.dto.TossSuccessResponse;
+import org.jungppo.bambooforest.global.oauth2.domain.CustomOAuth2User;
+import org.jungppo.bambooforest.member.domain.entity.MemberEntity;
+import org.jungppo.bambooforest.member.domain.entity.OAuth2Type;
+import org.jungppo.bambooforest.member.domain.entity.RoleType;
+import org.jungppo.bambooforest.member.domain.repository.MemberRepository;
+import org.jungppo.bambooforest.member.dto.PaymentConfirmRequest;
+import org.jungppo.bambooforest.member.dto.PaymentSetupRequest;
+import org.jungppo.bambooforest.member.dto.PaymentSetupResponse;
+import org.jungppo.bambooforest.member.exception.MemberNotFoundException;
+import org.jungppo.bambooforest.payment.service.PaymentService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class PaymentServiceConcurrencyTest {
+
+    @MockBean
+    private PaymentGatewayClient paymentGatewayClient;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PaymentService paymentService;
+
+    private CustomOAuth2User customOAuth2User;
+
+    @BeforeEach
+    void setUp() {
+        final MemberEntity memberEntity = MemberEntity.builder()
+                .name("testUser")
+                .oAuth2(OAuth2Type.OAUTH2_GITHUB)
+                .username("testUser")
+                .profileImage("testProfileImage")
+                .role(RoleType.ROLE_USER)
+                .build();
+
+        final MemberEntity savedMemberEntity = memberRepository.save(memberEntity);
+
+        customOAuth2User = new CustomOAuth2User(savedMemberEntity.getId(), savedMemberEntity.getRole(),
+                savedMemberEntity.getOAuth2());
+    }
+
+    @Test
+    void testSequentialPaymentRequests() {
+        final PaymentSetupRequest setupRequest1 = new PaymentSetupRequest(BatteryItem.SMALL_BATTERY.getName());
+        final PaymentSetupResponse setupResponse1 = paymentService.setupPayment(setupRequest1, customOAuth2User);
+
+        final PaymentSetupRequest setupRequest2 = new PaymentSetupRequest(BatteryItem.MEDIUM_BATTERY.getName());
+        final PaymentSetupResponse setupResponse2 = paymentService.setupPayment(setupRequest2, customOAuth2User);
+
+        final PaymentSetupRequest setupRequest3 = new PaymentSetupRequest(BatteryItem.LARGE_BATTERY.getName());
+        final PaymentSetupResponse setupResponse3 = paymentService.setupPayment(setupRequest3, customOAuth2User);
+
+        final PaymentConfirmRequest confirmRequest1 = new PaymentConfirmRequest(
+                "testPaymentKey1", setupResponse1.getOrderId(), setupResponse1.getAmount());
+
+        final PaymentConfirmRequest confirmRequest2 = new PaymentConfirmRequest(
+                "testPaymentKey2", setupResponse2.getOrderId(), setupResponse2.getAmount());
+
+        final PaymentConfirmRequest confirmRequest3 = new PaymentConfirmRequest(
+                "testPaymentKey3", setupResponse3.getOrderId(), setupResponse3.getAmount());
+
+        simulatePaymentSuccess(confirmRequest1.getPaymentKey(), confirmRequest1.getAmount(),
+                confirmRequest1.getOrderId());
+        simulatePaymentSuccess(confirmRequest2.getPaymentKey(), confirmRequest2.getAmount(),
+                confirmRequest2.getOrderId());
+        simulatePaymentSuccess(confirmRequest3.getPaymentKey(), confirmRequest3.getAmount(),
+                confirmRequest3.getOrderId());
+
+        try {
+            paymentService.confirmPayment(confirmRequest1);
+            paymentService.confirmPayment(confirmRequest2);
+            paymentService.confirmPayment(confirmRequest3);
+        } catch (final Exception e) {
+            System.out.println(e.getMessage());
+        }
+
+        final MemberEntity updatedMemberEntity = memberRepository.findById(customOAuth2User.getId())
+                .orElseThrow(MemberNotFoundException::new);
+
+        assertEquals(18, updatedMemberEntity.getBatteryCount(), "Remaining batteries should be 118");
+    }
+
+    @Test
+    void testConcurrentPaymentRequests() throws Exception {
+        final int numberOfThreads = 3;
+        final ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        final CountDownLatch countDownLatch = new CountDownLatch(numberOfThreads);
+
+        final PaymentSetupRequest setupRequest1 = new PaymentSetupRequest(BatteryItem.SMALL_BATTERY.getName());
+        final PaymentSetupResponse setupResponse1 = paymentService.setupPayment(setupRequest1, customOAuth2User);
+
+        final PaymentSetupRequest setupRequest2 = new PaymentSetupRequest(BatteryItem.MEDIUM_BATTERY.getName());
+        final PaymentSetupResponse setupResponse2 = paymentService.setupPayment(setupRequest2, customOAuth2User);
+
+        final PaymentSetupRequest setupRequest3 = new PaymentSetupRequest(BatteryItem.LARGE_BATTERY.getName());
+        final PaymentSetupResponse setupResponse3 = paymentService.setupPayment(setupRequest3, customOAuth2User);
+
+        final PaymentConfirmRequest confirmRequest1 = new PaymentConfirmRequest(
+                "testPaymentKey1", setupResponse1.getOrderId(), setupResponse1.getAmount());
+
+        final PaymentConfirmRequest confirmRequest2 = new PaymentConfirmRequest(
+                "testPaymentKey2", setupResponse2.getOrderId(), setupResponse2.getAmount());
+
+        final PaymentConfirmRequest confirmRequest3 = new PaymentConfirmRequest(
+                "testPaymentKey3", setupResponse3.getOrderId(), setupResponse3.getAmount());
+
+        simulatePaymentSuccess(confirmRequest1.getPaymentKey(), confirmRequest1.getAmount(),
+                confirmRequest1.getOrderId());
+        simulatePaymentSuccess(confirmRequest2.getPaymentKey(), confirmRequest2.getAmount(),
+                confirmRequest2.getOrderId());
+        simulatePaymentSuccess(confirmRequest3.getPaymentKey(), confirmRequest3.getAmount(),
+                confirmRequest3.getOrderId());
+
+        executorService.submit(() -> {
+            try {
+                paymentService.confirmPayment(confirmRequest1);
+            } catch (final Exception e) {
+                System.out.println(e.getMessage());
+            } finally {
+                countDownLatch.countDown();
+            }
+        });
+
+        executorService.submit(() -> {
+            try {
+                paymentService.confirmPayment(confirmRequest2);
+            } catch (final Exception e) {
+                System.out.println(e.getMessage());
+            } finally {
+                countDownLatch.countDown();
+            }
+        });
+
+        executorService.submit(() -> {
+            try {
+                paymentService.confirmPayment(confirmRequest3);
+            } catch (final Exception e) {
+                System.out.println(e.getMessage());
+            } finally {
+                countDownLatch.countDown();
+            }
+        });
+
+        countDownLatch.await();
+
+        final MemberEntity updatedMemberEntity = memberRepository.findById(customOAuth2User.getId())
+                .orElseThrow(MemberNotFoundException::new);
+
+        assertEquals(18, updatedMemberEntity.getBatteryCount(), "Remaining batteries should be 118");
+    }
+
+    private void simulatePaymentSuccess(String paymentKey, BigDecimal amount, UUID orderId) {
+        TossPaymentRequest paymentRequest = new TossPaymentRequest(paymentKey, orderId, amount);
+        TossSuccessResponse response = createMockTossSuccessResponse(paymentKey, amount, orderId);
+
+        when(paymentGatewayClient.payment(eq(paymentRequest))).thenReturn(ClientResponse.success(response));
+    }
+
+    private TossSuccessResponse createMockTossSuccessResponse(String paymentKey, BigDecimal amount,
+                                                              UUID orderId) {
+        return new TossSuccessResponse(
+                "1.0",
+                paymentKey,
+                "Normal",
+                orderId.toString(),
+                "Test Order",
+                "testMid",
+                "KRW",
+                "Card",
+                amount,
+                amount,
+                "Success",
+                OffsetDateTime.now(),
+                OffsetDateTime.now(),
+                false,
+                "transactionKey",
+                amount,
+                BigDecimal.ZERO,
+                false,
+                BigDecimal.ZERO,
+                0,
+                Collections.emptyList(),
+                new TossSuccessResponse.Card(amount, "issuerCode", "acquirerCode", "number", 0, "approveNo", false,
+                        "cardType", "ownerType", "acquireStatus", false, "interestPayer"),
+                new TossSuccessResponse.VirtualAccount("accountType", "accountNumber", "bankCode", "customerName",
+                        OffsetDateTime.now(), "refundStatus", false, "settlementStatus",
+                        new TossSuccessResponse.RefundReceiveAccount("bankCode", "accountNumber", "holderName"),
+                        "secret"),
+                new TossSuccessResponse.MobilePhone("customerMobilePhone", "settlementStatus", "receiptUrl"),
+                new TossSuccessResponse.GiftCertificate("approveNo", "settlementStatus"),
+                new TossSuccessResponse.Transfer("bankCode", "settlementStatus"),
+                new TossSuccessResponse.Receipt("url"),
+                new TossSuccessResponse.Checkout("url"),
+                new TossSuccessResponse.EasyPay("Toss", amount, BigDecimal.ZERO),
+                new TossSuccessResponse.Failure("code", "message"),
+                new TossSuccessResponse.CashReceipt("type", "receiptKey", "issueNumber", "receiptUrl", amount,
+                        BigDecimal.ZERO, "orderId", "orderName", "transactionType", "businessNumber", "issueStatus",
+                        "customerIdentityNumber", OffsetDateTime.now(),
+                        new TossSuccessResponse.Failure("code", "message")),
+                Collections.emptyList(),
+                new TossSuccessResponse.Discount(0),
+                "KR",
+                "secret",
+                false
+        );
+    }
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#issueNum)
-->

## 📌 관련 이슈

-  #10

## ✨ PR 세부 내용
- 배터리 구매 과정에서 발생하는 동시성 문제를 해결하기 위해 비관적(Pessimistic) Lock을 도입하였습니다.
  - 낙관적 Lock을 사용하지 못한 이유는 Toss API에 재요청을 할 경우 이미 처리된 요청으로 인식하고 에러를 반환하기 때문입니다. 이로 인해 낙관적 Lock을 사용할 수 없었으며, 대신 비관적 Lock을 사용하여 문제를 해결하였습니다.
<!-- 수정/추가한 내용을 적어주세요. -->
