### PR TITLE
chore : 지원하지 않는 챗봇일 경우 대응 로직 구현

### DIFF
--- a/src/main/java/org/jungppo/bambooforest/chatbot/domain/ChatBotItem.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/domain/ChatBotItem.java
@@ -9,23 +9,25 @@ import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.jungppo.bambooforest.chatbot.exception.ChatBotNotAvailableException;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ChatBotItem {
 
     UNCLE_CHATBOT("아저씨 챗봇", "http://example.com/uncle", "아저씨와 대화를 나눌 수 있는 챗봇입니다.",
-            "http://example.com/images/uncle.png", 0),
+            "http://example.com/images/uncle.png", 0, true),
     AUNT_CHATBOT("아줌마 챗봇", "http://example.com/aunt", "아줌마와 대화를 나눌 수 있는 챗봇입니다.",
-            "http://example.com/images/aunt.png", 3),
+            "http://example.com/images/aunt.png", 3, true),
     CHILD_CHATBOT("어린이 챗봇", "http://example.com/child", "어린이와 대화를 나눌 수 있는 챗봇입니다.",
-            "http://example.com/images/child.png", 5);
+            "http://example.com/images/child.png", 5, false);
 
     private final String name;
     private final String url;
     private final String description;
     private final String imageUrl;
     private final int price;
+    private final boolean available;
 
     private static final Map<String, ChatBotItem> CHATBOT_MAP;
 
@@ -36,5 +38,11 @@ public enum ChatBotItem {
 
     public static Optional<ChatBotItem> findByName(final String name) {
         return Optional.ofNullable(CHATBOT_MAP.get(name));
+    }
+
+    public void validateAvailability() {
+        if (!this.available) {
+            throw new ChatBotNotAvailableException();
+        }
     }
 }

--- a/src/main/java/org/jungppo/bambooforest/chatbot/dto/ChatBotItemDto.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/dto/ChatBotItemDto.java
@@ -12,6 +12,7 @@ public class ChatBotItemDto {
     private final String description;
     private final String imageUrl;
     private final int price;
+    private final boolean available;
 
     public static ChatBotItemDto from(final ChatBotItem chatBotItem) {
         return new ChatBotItemDto(
@@ -19,7 +20,8 @@ public class ChatBotItemDto {
                 chatBotItem.getUrl(),
                 chatBotItem.getDescription(),
                 chatBotItem.getImageUrl(),
-                chatBotItem.getPrice()
+                chatBotItem.getPrice(),
+                chatBotItem.isAvailable()
         );
     }
 }

--- a/src/main/java/org/jungppo/bambooforest/chatbot/exception/ChatBotNotAvailableException.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/exception/ChatBotNotAvailableException.java
@@ -1,0 +1,9 @@
+package org.jungppo.bambooforest.chatbot.exception;
+
+import static org.jungppo.bambooforest.global.exception.domain.ExceptionType.CHATBOT_NOT_AVAILABLE_EXCEPTION;
+
+public class ChatBotNotAvailableException extends ChatBotBusinessException {
+    public ChatBotNotAvailableException() {
+        super(CHATBOT_NOT_AVAILABLE_EXCEPTION);
+    }
+}

--- a/src/main/java/org/jungppo/bambooforest/chatbot/service/ChatBotPurchaseService.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/service/ChatBotPurchaseService.java
@@ -35,9 +35,10 @@ public class ChatBotPurchaseService {
                                 final CustomOAuth2User customOAuth2User) {
         final ChatBotItem chatBotItem = ChatBotItem.findByName(chatBotPurchaseRequest.getChatBotItemName())
                 .orElseThrow(ChatBotNotFoundException::new);
+        chatBotItem.validateAvailability();
+
         final MemberEntity memberEntity = memberRepository.findByIdWithOptimisticLock(customOAuth2User.getId())
                 .orElseThrow(MemberNotFoundException::new);
-
         memberEntity.subtractBatteries(chatBotItem.getPrice());
         memberEntity.addChatBot(chatBotItem);
 

--- a/src/main/java/org/jungppo/bambooforest/global/exception/domain/ExceptionType.java
+++ b/src/main/java/org/jungppo/bambooforest/global/exception/domain/ExceptionType.java
@@ -32,6 +32,7 @@ public enum ExceptionType {
     CHATBOT_ALREADY_OWNED_EXCEPTION(BAD_REQUEST, "E016", "The specified chatBot item is already owned by the user."),
     CHATBOT_PURCHASE_NOT_FOUND_EXCEPTION(NOT_FOUND, "E017", "The specified chatBot purchase could not be found."),
     ROOM_NOT_FOUND_EXCEPTION(NOT_FOUND, "E018", "The specified room could not be found."),
+    CHATBOT_NOT_AVAILABLE_EXCEPTION(BAD_REQUEST, "E019", "The specified chatBot item is not available for purchase."),
     ;
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/org/jungppo/bambooforest/payment/service/PaymentService.java
+++ b/src/main/java/org/jungppo/bambooforest/payment/service/PaymentService.java
@@ -56,8 +56,9 @@ public class PaymentService {
 
     @Transactional
     @PreAuthorize(value = "@paymentAccessEvaluator.isEligible(#paymentConfirmRequest.getOrderId(), #customOAuth2User.getId())")
-    public UUID confirmPayment(final PaymentConfirmRequest paymentConfirmRequest,
-                               final CustomOAuth2User customOAuth2User) {
+    public UUID confirmPayment(
+            @Param(value = "paymentConfirmRequest") final PaymentConfirmRequest paymentConfirmRequest,
+            @Param(value = "customOAuth2User") final CustomOAuth2User customOAuth2User) {
         final PaymentEntity paymentEntity = paymentRepository.findById(paymentConfirmRequest.getOrderId())
                 .orElseThrow(PaymentNotFoundException::new);
 

--- a/src/test/java/org/jungppo/bambooforest/ChatBotPurchaseServiceConcurrencyTest.java
+++ b/src/test/java/org/jungppo/bambooforest/ChatBotPurchaseServiceConcurrencyTest.java
@@ -1,7 +1,6 @@
 package org.jungppo.bambooforest;
 
 import static org.jungppo.bambooforest.chatbot.domain.ChatBotItem.AUNT_CHATBOT;
-import static org.jungppo.bambooforest.chatbot.domain.ChatBotItem.CHILD_CHATBOT;
 import static org.jungppo.bambooforest.chatbot.domain.ChatBotItem.UNCLE_CHATBOT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -60,12 +59,10 @@ public class ChatBotPurchaseServiceConcurrencyTest {
     void testSequentialPurchaseRequests() {
         final ChatBotPurchaseRequest purchaseRequest1 = new ChatBotPurchaseRequest(UNCLE_CHATBOT.getName());
         final ChatBotPurchaseRequest purchaseRequest2 = new ChatBotPurchaseRequest(AUNT_CHATBOT.getName());
-        final ChatBotPurchaseRequest purchaseRequest3 = new ChatBotPurchaseRequest(CHILD_CHATBOT.getName());
 
         try {
             chatBotPurchaseService.purchaseChatBot(purchaseRequest1, customOAuth2User);
             chatBotPurchaseService.purchaseChatBot(purchaseRequest2, customOAuth2User);
-            chatBotPurchaseService.purchaseChatBot(purchaseRequest3, customOAuth2User);
         } catch (final Exception e) {
             System.out.println(e.getMessage());
         }
@@ -73,27 +70,24 @@ public class ChatBotPurchaseServiceConcurrencyTest {
         final MemberEntity updatedMemberEntity = memberRepository.findById(customOAuth2User.getId())
                 .orElseThrow(MemberNotFoundException::new);
 
-        assertEquals(92, updatedMemberEntity.getBatteryCount(),
+        assertEquals(97, updatedMemberEntity.getBatteryCount(),
                 "Remaining batteries should be 92");
         assertTrue(updatedMemberEntity.getChatBots().contains(UNCLE_CHATBOT),
                 "Purchased chatbots should contain UNCLE_CHATBOT");
         assertTrue(updatedMemberEntity.getChatBots().contains(AUNT_CHATBOT),
                 "Purchased chatbots should contain AUNT_CHATBOT");
-        assertTrue(updatedMemberEntity.getChatBots().contains(CHILD_CHATBOT),
-                "Purchased chatbots should contain CHILD_CHATBOT");
     }
 
     @Test
     void testConcurrentPurchaseRequests() throws InterruptedException {
-        final int numberOfThreads = 3;
-        final ExecutorService executorService = Executors.newFixedThreadPool(3);
+        final int numberOfThreads = 2;
+        final ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
         final CountDownLatch countDownLatch = new CountDownLatch(numberOfThreads);
 
         final ChatBotPurchaseRequest purchaseRequest1 = new ChatBotPurchaseRequest(UNCLE_CHATBOT.getName());
         final ChatBotPurchaseRequest purchaseRequest2 = new ChatBotPurchaseRequest(AUNT_CHATBOT.getName());
-        final ChatBotPurchaseRequest purchaseRequest3 = new ChatBotPurchaseRequest(CHILD_CHATBOT.getName());
 
-        final ChatBotPurchaseRequest[] purchaseRequests = {purchaseRequest1, purchaseRequest2, purchaseRequest3};
+        final ChatBotPurchaseRequest[] purchaseRequests = {purchaseRequest1, purchaseRequest2};
 
         for (final ChatBotPurchaseRequest purchaseRequest : purchaseRequests) {
             executorService.submit(() -> {
@@ -112,13 +106,11 @@ public class ChatBotPurchaseServiceConcurrencyTest {
         final MemberEntity updatedMemberEntity = memberRepository.findById(customOAuth2User.getId())
                 .orElseThrow(MemberNotFoundException::new);
 
-        assertEquals(92, updatedMemberEntity.getBatteryCount(),
+        assertEquals(97, updatedMemberEntity.getBatteryCount(),
                 "Remaining batteries should be 92");
         assertTrue(updatedMemberEntity.getChatBots().contains(UNCLE_CHATBOT),
                 "Purchased chatbots should contain UNCLE_CHATBOT");
         assertTrue(updatedMemberEntity.getChatBots().contains(AUNT_CHATBOT),
                 "Purchased chatbots should contain AUNT_CHATBOT");
-        assertTrue(updatedMemberEntity.getChatBots().contains(CHILD_CHATBOT),
-                "Purchased chatbots should contain CHILD_CHATBOT");
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- #20

## ✨ PR 세부 내용
- 지원하지 않는 챗봇도 있다는 바뀐 기획에 따라 대응하는 간단한 로직을 구현하였습니다.
  - 지원하지 않는 챗봇일 경우 사용할 예외 정의
  - 챗봇 구매 시 이용가능 여부 검사 로직 추가
  - 챗봇 정보 조회에서 이용 가능 정보를 반환하도록 수정
<!-- 수정/추가한 내용을 적어주세요. -->
