### PR TITLE
perf : 복합 인덱스를 이용한 조회 성능 향상 시도

### DIFF
--- a/src/main/java/org/jungppo/bambooforest/chatbot/domain/entity/ChatBotPurchaseEntity.java
+++ b/src/main/java/org/jungppo/bambooforest/chatbot/domain/entity/ChatBotPurchaseEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -23,7 +24,10 @@ import org.jungppo.bambooforest.member.domain.entity.MemberEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "chatbot_purchase")
+@Table(name = "chatbot_purchase",
+        indexes = {
+                @Index(name = "idx_member_id_created_at", columnList = "member_id, created_at")
+        })
 public class ChatBotPurchaseEntity extends JpaBaseEntity {
 
     @Id

--- a/src/main/java/org/jungppo/bambooforest/payment/domain/entity/PaymentEntity.java
+++ b/src/main/java/org/jungppo/bambooforest/payment/domain/entity/PaymentEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -25,7 +26,10 @@ import org.jungppo.bambooforest.member.domain.entity.MemberEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "payment")
+@Table(name = "payment",
+        indexes = {
+                @Index(name = "idx_member_id_status_created_at", columnList = "member_id, status, created_at")
+        })
 public class PaymentEntity extends JpaBaseEntity {
 
     @Id

--- a/src/test/java/org/jungppo/bambooforest/concurrency/ChatBotPurchaseServiceConcurrencyTest.java
+++ b/src/test/java/org/jungppo/bambooforest/concurrency/ChatBotPurchaseServiceConcurrencyTest.java
@@ -1,4 +1,4 @@
-package org.jungppo.bambooforest;
+package org.jungppo.bambooforest.concurrency;
 
 import static org.jungppo.bambooforest.chatbot.domain.ChatBotItem.AUNT_CHATBOT;
 import static org.jungppo.bambooforest.chatbot.domain.ChatBotItem.UNCLE_CHATBOT;
@@ -16,6 +16,7 @@ import org.jungppo.bambooforest.member.domain.entity.OAuth2Type;
 import org.jungppo.bambooforest.member.domain.entity.RoleType;
 import org.jungppo.bambooforest.member.domain.repository.MemberRepository;
 import org.jungppo.bambooforest.member.exception.MemberNotFoundException;
+import org.jungppo.bambooforest.util.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/org/jungppo/bambooforest/concurrency/PaymentServiceConcurrencyTest.java
+++ b/src/test/java/org/jungppo/bambooforest/concurrency/PaymentServiceConcurrencyTest.java
@@ -1,4 +1,4 @@
-package org.jungppo.bambooforest;
+package org.jungppo.bambooforest.concurrency;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
@@ -26,6 +26,7 @@ import org.jungppo.bambooforest.member.dto.PaymentSetupRequest;
 import org.jungppo.bambooforest.member.dto.PaymentSetupResponse;
 import org.jungppo.bambooforest.member.exception.MemberNotFoundException;
 import org.jungppo.bambooforest.payment.service.PaymentService;
+import org.jungppo.bambooforest.util.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/org/jungppo/bambooforest/performance/ChatBotPurchaseServicePerformanceTest.java
+++ b/src/test/java/org/jungppo/bambooforest/performance/ChatBotPurchaseServicePerformanceTest.java
@@ -1,0 +1,32 @@
+package org.jungppo.bambooforest.performance;
+
+import java.util.List;
+import org.jungppo.bambooforest.chatbot.dto.ChatBotPurchaseDto;
+import org.jungppo.bambooforest.chatbot.service.ChatBotPurchaseService;
+import org.jungppo.bambooforest.global.oauth2.domain.CustomOAuth2User;
+import org.jungppo.bambooforest.member.domain.entity.OAuth2Type;
+import org.jungppo.bambooforest.member.domain.entity.RoleType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class ChatBotPurchaseServicePerformanceTest {
+
+    @Autowired
+    private ChatBotPurchaseService chatBotPurchaseService;
+
+    @Test
+    void testGetChatBotPurchasesPerformance() {
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(1L, RoleType.ROLE_USER, OAuth2Type.OAUTH2_GITHUB);
+
+        long startTime = System.nanoTime();
+        List<ChatBotPurchaseDto> purchases = chatBotPurchaseService.getChatBotPurchases(customOAuth2User);
+        long endTime = System.nanoTime();
+        long duration = endTime - startTime;
+        System.out.println("Execution time: " + duration + " nanoseconds");
+        System.out.println("purchases: " + purchases);
+    }
+}

--- a/src/test/java/org/jungppo/bambooforest/performance/PaymentServicePerformanceTest.java
+++ b/src/test/java/org/jungppo/bambooforest/performance/PaymentServicePerformanceTest.java
@@ -1,0 +1,32 @@
+package org.jungppo.bambooforest.performance;
+
+import java.util.List;
+import org.jungppo.bambooforest.global.oauth2.domain.CustomOAuth2User;
+import org.jungppo.bambooforest.member.domain.entity.OAuth2Type;
+import org.jungppo.bambooforest.member.domain.entity.RoleType;
+import org.jungppo.bambooforest.member.dto.PaymentDto;
+import org.jungppo.bambooforest.payment.service.PaymentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class PaymentServicePerformanceTest {
+
+    @Autowired
+    private PaymentService paymentService;
+
+    @Test
+    void testGetPaymentsPerformance() {
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(1L, RoleType.ROLE_USER, OAuth2Type.OAUTH2_GITHUB);
+
+        long startTime = System.nanoTime();
+        List<PaymentDto> payments = paymentService.getPayments(customOAuth2User);
+        long endTime = System.nanoTime();
+        long duration = endTime - startTime;
+        System.out.println("Execution time: " + duration + " nanoseconds");
+        System.out.println("payments: " + payments);
+    }
+}

--- a/src/test/java/org/jungppo/bambooforest/performance/dml/GetChatBotPurchasesPerformanceTest.sql
+++ b/src/test/java/org/jungppo/bambooforest/performance/dml/GetChatBotPurchasesPerformanceTest.sql
@@ -1,0 +1,29 @@
+EXPLAIN ANALYZE
+SELECT *
+FROM chatbot_purchase
+WHERE member_id = 1
+ORDER BY created_at DESC;
+
+INSERT INTO member (member_id, name, o_auth2, username, profile_image, role, created_at, modified_at, version,
+                    battery_count, chat_bots)
+SELECT gs AS member_id,
+       'user' || gs,
+       'OAUTH2_GITHUB',
+       'user' || gs,
+       'profile' || gs || '.jpg',
+       'ROLE_USER',
+       NOW(),
+       NOW(),
+       0,
+       100,
+       ''
+FROM generate_series(1, 2000) AS gs;
+
+INSERT INTO chatbot_purchase (chatbot_purchase_id, amount, chat_bot_item, member_id, created_at, modified_at)
+SELECT gs AS chatbot_purchase_id,
+       CASE WHEN RANDOM() < 0.5 THEN 10 ELSE 20 END,
+       CASE WHEN RANDOM() < 0.5 THEN 'UNCLE_CHATBOT' ELSE 'AUNT_CHATBOT' END,
+       (RANDOM() * 99)::int + 1,
+       TIMESTAMP '2022-01-01 00:00:00' + (RANDOM() * (INTERVAL '365 days')),
+       TIMESTAMP '2022-01-01 00:00:00' + (RANDOM() * (INTERVAL '365 days'))
+FROM generate_series(1, 4000) AS gs;

--- a/src/test/java/org/jungppo/bambooforest/performance/dml/GetPaymentPerformanceTest.sql
+++ b/src/test/java/org/jungppo/bambooforest/performance/dml/GetPaymentPerformanceTest.sql
@@ -1,0 +1,45 @@
+EXPLAIN ANALYZE
+SELECT *
+FROM payment
+WHERE member_id = 1
+  AND status = 'COMPLETED'
+ORDER BY created_at DESC;
+
+INSERT INTO member (member_id, name, o_auth2, username, profile_image, role, created_at, modified_at, version,
+                    battery_count, chat_bots)
+SELECT gs AS member_id,
+       'user' || gs,
+       'OAUTH2_GITHUB',
+       'user' || gs,
+       'profile' || gs || '.jpg',
+       'ROLE_USER',
+       NOW(),
+       NOW(),
+       0,
+       100,
+       ''
+FROM generate_series(1, 2000) gs;
+
+INSERT INTO payment (payment_id, status, battery_item, member_id, key, provider, amount, created_at, modified_at)
+SELECT uuid_generate_v4(),
+       CASE WHEN RANDOM() < 0.5 THEN 'COMPLETED' ELSE 'PENDING' END,
+       CASE
+           WHEN RANDOM() < 0.2 THEN 'SMALL_BATTERY'
+           WHEN RANDOM() < 0.4 THEN 'MEDIUM_BATTERY'
+           WHEN RANDOM() < 0.6 THEN 'LARGE_BATTERY'
+           WHEN RANDOM() < 0.8 THEN 'SMALL_BATTERY_PACK'
+           ELSE 'MEDIUM_BATTERY_PACK'
+           END,
+       (RANDOM() * 99)::int + 1,
+       md5(random()::text),
+       'provider' || (RANDOM() * 10)::int,
+       CASE
+           WHEN RANDOM() < 0.2 THEN 3000
+           WHEN RANDOM() < 0.4 THEN 5000
+           WHEN RANDOM() < 0.6 THEN 10000
+           WHEN RANDOM() < 0.8 THEN 20000
+           ELSE 50000
+           END::numeric,
+       TIMESTAMP '2022-01-01 00:00:00' + (RANDOM() * (INTERVAL '365 days')),
+       TIMESTAMP '2022-01-01 00:00:00' + (RANDOM() * (INTERVAL '365 days'))
+FROM generate_series(1, 100000) AS gs;

--- a/src/test/java/org/jungppo/bambooforest/util/DatabaseCleaner.java
+++ b/src/test/java/org/jungppo/bambooforest/util/DatabaseCleaner.java
@@ -1,4 +1,4 @@
-package org.jungppo.bambooforest;
+package org.jungppo.bambooforest.util;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#issueNum)
-->

## 📌 관련 이슈

- #17, #26

## ✨ PR 세부 내용
테스트 환경은 해커톤 환경에 기반하여 2000명의 사용자로 예상하여 구성하였습니다.

1. **payment entity에 복합 인덱스를 이용한 조회 성능 향상 시도**
   - 2000명의 인원이 50번의 결제를 시도하였을 경우
     - EXPLAIN ANALYZE
       -  인덱스 적용 전 
         ![image](https://github.com/user-attachments/assets/c1933a7f-fd5d-429e-8891-72deb21003d6)
       -  인덱스 적용 후
         ![image](https://github.com/user-attachments/assets/2236af44-b0d0-4b7e-900c-27cacb5a02ba)
     - 실제 실행
       -  인덱스 적용 전 
           - 평균 실행 시간: 511,865,800 ns
       -  인덱스 적용 후
           - 평균 실행 시간: 478,125,700 ns
        
     - **분석 결과**
       - Execution Time이 약 15.494 ms에서 0.619 ms로 감소하여 실제 쿼리 실행 시간이 단축되었습니다.
       - 인덱스 적용 후 평균 실행 시간이 약 33,740,100 ns 감소하여 약 6.59%의 성능 향상이 있었습니다.

2. **chatBotPurchase entity에 복합 인덱스를 이용한 조회 성능 향상 시도**
   - 2000명의 인원이 2개의 챗봇을 구매하였을 경우
     - EXPLAIN ANALYZE
       -  인덱스 적용 전 
         ![image](https://github.com/user-attachments/assets/7f4117d8-c949-49f7-9ca7-449252534390)
       -  인덱스 적용 후
         ![image](https://github.com/user-attachments/assets/b22cd7f9-6f58-474f-b123-20f0e476ad2c)
     - 실제 실행
       -  인덱스 적용 전 
          - 평균 실행 시간: 489,639,500 ns
       -  인덱스 적용 후
           - 평균 실행 시간: 433,720,750 ns
        
     - **분석 결과**
       - Execution Time이 약 0.428 ms에서 0.170 ms로 감소하여 실제 쿼리 실행 시간이 단축되었습니다.
       - 인덱스 적용 후 평균 실행 시간이 약 55,918,750 ns 감소하여 약 11.42%의 성능 향상이 있었습니다.

