### PR TITLE
refactor : JdbcOAuth2AuthorizedClientService가 상속보다는 컴포지션을 사용하도록 변경

### DIFF
--- a/src/main/java/org/jungppo/bambooforest/global/config/SecurityConfig.java
+++ b/src/main/java/org/jungppo/bambooforest/global/config/SecurityConfig.java
@@ -8,9 +8,9 @@ import org.jungppo.bambooforest.global.jwt.presentation.CustomAuthenticationEntr
 import org.jungppo.bambooforest.global.jwt.presentation.JwtAuthenticationFilter;
 import org.jungppo.bambooforest.global.oauth2.presentation.CustomOAuth2LoginFailureHandler;
 import org.jungppo.bambooforest.global.oauth2.presentation.CustomOAuth2LoginSuccessHandler;
-import org.jungppo.bambooforest.global.oauth2.service.CustomJdbcOAuth2AuthorizedClientService;
 import org.jungppo.bambooforest.global.oauth2.service.CustomOAuth2UserService;
 import org.jungppo.bambooforest.global.oauth2.service.HttpCookieOAuth2AuthorizationRequestRepository;
+import org.jungppo.bambooforest.global.oauth2.service.JdbcOAuth2AuthorizedClientServiceProxy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -23,6 +23,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -43,7 +44,7 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager authenticationManager,
-                                           CustomJdbcOAuth2AuthorizedClientService customJdbcOAuth2AuthorizedClientService)
+                                           OAuth2AuthorizedClientService jdbcOAuth2AuthorizedClientServiceProxy)
             throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
@@ -67,7 +68,7 @@ public class SecurityConfig {
                                 config -> config.authorizationRequestRepository(
                                         httpCookieOAuth2AuthorizationRequestRepository))
                         .userInfoEndpoint(config -> config.userService(customOAuth2UserService))
-                        .authorizedClientService(customJdbcOAuth2AuthorizedClientService)
+                        .authorizedClientService(jdbcOAuth2AuthorizedClientServiceProxy)
                         .successHandler(customOauth2LoginSuccessHandler)
                         .failureHandler(customOauth2LoginFailureHandler)
                 )
@@ -85,8 +86,8 @@ public class SecurityConfig {
     }
 
     @Bean
-    public CustomJdbcOAuth2AuthorizedClientService customJdbcOAuth2AuthorizedClientService(JdbcTemplate jdbcTemplate,
-                                                                                           ClientRegistrationRepository clientRegistrationRepository) {
-        return new CustomJdbcOAuth2AuthorizedClientService(jdbcTemplate, clientRegistrationRepository);
+    public OAuth2AuthorizedClientService jdbcOAuth2AuthorizedClientServiceProxy(JdbcTemplate jdbcTemplate,
+                                                                                ClientRegistrationRepository clientRegistrationRepository) {
+        return new JdbcOAuth2AuthorizedClientServiceProxy(jdbcTemplate, clientRegistrationRepository);
     }
 }

--- a/src/main/java/org/jungppo/bambooforest/global/oauth2/service/JdbcOAuth2AuthorizedClientServiceProxy.java
+++ b/src/main/java/org/jungppo/bambooforest/global/oauth2/service/JdbcOAuth2AuthorizedClientServiceProxy.java
@@ -1,36 +1,38 @@
 package org.jungppo.bambooforest.global.oauth2.service;
 
 import org.springframework.jdbc.core.JdbcOperations;
-import org.springframework.jdbc.support.lob.DefaultLobHandler;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.JdbcOAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.transaction.annotation.Transactional;
 
-public class CustomJdbcOAuth2AuthorizedClientService extends JdbcOAuth2AuthorizedClientService {
+public class JdbcOAuth2AuthorizedClientServiceProxy implements OAuth2AuthorizedClientService {
 
-    public CustomJdbcOAuth2AuthorizedClientService(JdbcOperations jdbcOperations,
-                                                   ClientRegistrationRepository clientRegistrationRepository) {
-        super(jdbcOperations, clientRegistrationRepository, new DefaultLobHandler());
+    private final OAuth2AuthorizedClientService delegate;
+
+    public JdbcOAuth2AuthorizedClientServiceProxy(JdbcOperations jdbcOperations,
+                                                  ClientRegistrationRepository clientRegistrationRepository) {
+        this.delegate = new JdbcOAuth2AuthorizedClientService(jdbcOperations, clientRegistrationRepository);
     }
 
     @Override
     @Transactional
     public <T extends OAuth2AuthorizedClient> T loadAuthorizedClient(String clientRegistrationId,
                                                                      String principalName) {
-        return super.loadAuthorizedClient(clientRegistrationId, principalName);
+        return delegate.loadAuthorizedClient(clientRegistrationId, principalName);
     }
 
     @Override
     @Transactional
     public void saveAuthorizedClient(OAuth2AuthorizedClient authorizedClient, Authentication principal) {
-        super.saveAuthorizedClient(authorizedClient, principal);
+        delegate.saveAuthorizedClient(authorizedClient, principal);
     }
 
     @Override
     @Transactional
     public void removeAuthorizedClient(String clientRegistrationId, String principalName) {
-        super.removeAuthorizedClient(clientRegistrationId, principalName);
+        delegate.removeAuthorizedClient(clientRegistrationId, principalName);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #56

## ✨ PR 세부 내용
- JdbcOAuth2AuthorizedClientService가 상속 대신 컴포지션을 사용하도록 리팩토링하였습니다. 컴포지션을 통해 더 유연하고 유지보수하기 쉬운 구조를 만들고, 상속으로 인한 강한 결합을 피하기 위함입니다.
- 또한 MemberService에서 구체클래스가 아닌, OAuth2AuthorizedClientService 인터페이스에 의존하도록 변경되었습니다.
