### PR TITLE
refactor : 회원 탈퇴에 대한 Cascade 처리를 Spring Event로 처리하도록 변경

### DIFF
--- a/src/main/java/org/jungppo/bambooforest/global/listener/DeleteEventListener.java
+++ b/src/main/java/org/jungppo/bambooforest/global/listener/DeleteEventListener.java
@@ -1,0 +1,32 @@
+package org.jungppo.bambooforest.global.listener;
+
+import static org.springframework.transaction.annotation.Propagation.MANDATORY;
+
+import lombok.RequiredArgsConstructor;
+import org.jungppo.bambooforest.chat.domain.repository.ChatMessageRepository;
+import org.jungppo.bambooforest.chat.domain.repository.ChatRoomRepository;
+import org.jungppo.bambooforest.chatbot.domain.repository.ChatBotPurchaseRepository;
+import org.jungppo.bambooforest.member.domain.MemberDeleteEvent;
+import org.jungppo.bambooforest.payment.domain.repository.PaymentRepository;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class DeleteEventListener {
+
+    private final PaymentRepository paymentRepository;
+    private final ChatBotPurchaseRepository chatBotPurchaseRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    @EventListener
+    @Transactional(propagation = MANDATORY)
+    public void deleteMember(final MemberDeleteEvent memberDeleteEvent) {
+        chatMessageRepository.deleteAllByMemberId(memberDeleteEvent.getMemberId());
+        chatRoomRepository.deleteAllByMemberId(memberDeleteEvent.getMemberId());
+        chatBotPurchaseRepository.deleteAllByMemberId(memberDeleteEvent.getMemberId());
+        paymentRepository.deleteAllByMemberId(memberDeleteEvent.getMemberId());
+    }
+}

--- a/src/main/java/org/jungppo/bambooforest/member/domain/MemberDeleteEvent.java
+++ b/src/main/java/org/jungppo/bambooforest/member/domain/MemberDeleteEvent.java
@@ -1,0 +1,10 @@
+package org.jungppo.bambooforest.member.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberDeleteEvent {
+    private final Long memberId;
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#issueNum)
-->

## 📌 관련 이슈

- #56

## ✨ PR 세부 내용
- 회원 탈퇴 시 연관된 데이터 삭제를 Spring Event로 처리하여 코드의 의존성을 줄였습니다.
- 이를 통해 코드가 더 유연해졌고, 테스트 코드 작성이 용이해졌습니다.

<!-- 수정/추가한 내용을 적어주세요. -->
