### PR TITLE
feat : tomcat 정보를 모니터링 할 수 있도록 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 server:
   port: 8080
 
+  tomcat:
+    mbean-registry:
+      enabled: true
+      
 spring:
   profiles:
     default: local


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#issueNum)
-->

## 📌 관련 이슈

- #44 

## ✨ PR 세부 내용
- Prometheus에서 Tomcat의 JMX 데이터를 수집할 수 있도록 tomcat 설정 내 mbean-registry 옵션을 enabled: true로 변경하였습니다.
- 이를 통해 Grafana에서 Tomcat의 쓰레드 풀 상태, JDBC 커넥션 풀 상태, HTTP 세션 상태, 메모리 사용량 등을 모니터링할 수 있습니다.
